### PR TITLE
Definição de padrão para DapperColumn

### DIFF
--- a/src/Dapper/DapperMapper/Program.cs
+++ b/src/Dapper/DapperMapper/Program.cs
@@ -10,13 +10,13 @@ namespace DapperMapper.Console
         static void Main(string[] args)
         {
 
-            //var repoNovo = new TabelaTesteDapperMapper(StringConnection);
+            var repoNovo = new TabelaTesteDapperMapper(StringConnection);
 
             //var repoAntigo = new TabelaTesteRepository(StringConnection);
 
             ////var regioes = repoNovo.GetAll();
 
-            //repoNovo.Insert(new TabelaTeste { Campo1 = "Campo 1" });
+            repoNovo.Insert(new TabelaTeste { Campo1 = "Campo 1" });
             //repoAntigo.Insert(new TabelaTeste { Campo1 = "Campo 2" });
 
             //var regiao = repoNovo.GetById(9);

--- a/src/Dapper/DapperMapper/TabelaTeste.cs
+++ b/src/Dapper/DapperMapper/TabelaTeste.cs
@@ -6,42 +6,37 @@ namespace DapperMapper.Console
     [DapperTable("TabelaTeste")]
     public class TabelaTeste
     {
-
-        public TabelaTeste()
-        {
-            Id = Guid.NewGuid();
-        }
         [DapperColumn(PrimaryKey = true)]
         public Guid Id { get; set; }
 
-        [DapperColumn]
+
         public string Campo1 { get; set; }
 
-        [DapperColumn]
+
         public string Campo2 { get; set; }
 
-        [DapperColumn]
+
         public string Campo3 { get; set; }
 
-        [DapperColumn]
+
         public string Campo4 { get; set; }
 
-        [DapperColumn]
+
         public string Campo5 { get; set; }
 
-        [DapperColumn]
+
         public string Campo6 { get; set; }
 
-        [DapperColumn]
+
         public string Campo7 { get; set; }
 
-        [DapperColumn]
+
         public string Campo8 { get; set; }
 
-        [DapperColumn]
+
         public string Campo9 { get; set; }
 
-        [DapperColumn]
+
         public string Campo10 { get; set; }
     }
 }

--- a/src/DapperMapper/Attributes/DapperColumn.cs
+++ b/src/DapperMapper/Attributes/DapperColumn.cs
@@ -7,10 +7,11 @@ namespace DapperMapper.Attributes
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class DapperColumn : Attribute
     {
-        public DapperColumn([CallerMemberName] string columnName = "", bool primaryKey = false)
+        public DapperColumn([CallerMemberName] string columnName = "", bool primaryKey = false, AutoSync sync = AutoSync.Ever)
         {
             ColumnName = columnName;
             PrimaryKey = primaryKey;
+            Sync = sync;
         }
 
         public string ColumnName { get; set; }

--- a/src/DapperMapper/Mapper/MappedEntityProperty.cs
+++ b/src/DapperMapper/Mapper/MappedEntityProperty.cs
@@ -9,7 +9,7 @@ namespace DapperMapper.Mapper
         public MappedEntityProperty(PropertyInfo property, DapperColumn dapperColumn)
         {
             Property = property;
-            DapperColumn = dapperColumn;
+            DapperColumn = dapperColumn ?? new DapperColumn(property.Name);
             Setter = FasterInvoker.BuildUntypedSetter<T>(property);
             Getter = FasterInvoker.BuildUntypedGetter<T>(property);
         }


### PR DESCRIPTION
Ao definir o atributo DapperTable não é necessário definir o DapperColumn nas outras entidades que passam a ser consideradas por padrão no mapping. Coluna de Primary Key ainda são necessárias. 